### PR TITLE
require node-fetch package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "localtunnel": "1.9.0",
+    "node-fetch": "^2.1.2",
     "ws": "^3.3.3",
     "zoapp-core": "^0.12.0",
     "zoauth-server": "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,6 +2784,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"


### PR DESCRIPTION
I would like to nerge this first, publish a new version and then replace in `opla/backend` the usage of `fetch`.

WDYT ?