### PR TITLE
make config simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ you can directly use its name:
 $ yarn add zrmc
 ```
 
+## Configuration
+There is a default configuration that lies in `src/defaultAppConfig.js`.
+This default configuration can be overriden by passing a config object to the `createZoapp` function.
+It also can be overriden with environment variables like the following :
+To override `global.database.host`, inject the following env variable : `ZOAPP__GLOBAL__DATABASE__HOST`.
+
+As a consequence, use `_` rather than camelCase in config keys.
+
 
 ## Contributor Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ To override `global.database.host`, inject the following env variable : `ZOAPP__
 
 As a consequence, use `_` rather than camelCase in config keys.
 
+### Config sources & priorities
+1. Environment vars starting with `ZOAPP_`
+2. Config in `createZoapp(config, ...)`
+3. Fallback to `./src/defaultAppConfig.js`
 
 ## Contributor Code of Conduct
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "name": "Zoapp Example app"
+}

--- a/src/app.js
+++ b/src/app.js
@@ -72,7 +72,7 @@ export class App {
   }
 
   get buildSchema() {
-    return this.configuration.buildSchema;
+    return this.configuration.build_schema;
   }
 
   /**

--- a/src/controllers/abstractController.js
+++ b/src/controllers/abstractController.js
@@ -29,9 +29,9 @@ class AbstractController {
 
   async open() {
     if (this.model) {
-      const { buildSchema } = this.main.config;
+      const { build_schema } = this.main.config;
 
-      await this.model.open(buildSchema);
+      await this.model.open(build_schema);
     }
   }
 

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -78,13 +78,12 @@ export default class extends AbstractController {
       );
     }
 
-    // Override with env variables.
-    parameters.backend.publicUrl =
-      process.env.ZOAPP_PUBLIC_URL || parameters.backend.publicUrl;
-    parameters.backend.apiUrl =
-      process.env.ZOAPP_API_URL || parameters.backend.apiUrl;
-    parameters.backend.authUrl =
-      process.env.ZOAPP_AUTH_URL || parameters.backend.authUrl;
+    // Get backend url params from config.
+    const cfg = this.main.config;
+    parameters.backend.publicUrl = cfg.global.public_url;
+    parameters.backend.apiUrl = cfg.global.api_url;
+    parameters.backend.authUrl = cfg.global.auth_url;
+    parameters.backend.managementEndpoint = cfg.global.management_endpoint;
 
     if (!parameters.backend.publicUrl) {
       logger.info("tunnel.active=", parameters.backend.tunnel.active);
@@ -96,7 +95,6 @@ export default class extends AbstractController {
       }
     }
 
-    const cfg = this.main.config;
     if (!parameters.backend.apiUrl) {
       parameters.backend.apiUrl = [
         `${cfg.global.api.ip}:${cfg.global.api.port}`,

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -37,9 +37,9 @@ class MainController {
   }
 
   async start() {
-    const { buildSchema } = this.config;
+    const { build_schema } = this.config;
 
-    await this.parameters.open(buildSchema);
+    await this.parameters.open(build_schema);
     await this.middlewares.open();
     await this.admin.open();
     await this.users.open();

--- a/src/defaultAppConfig.js
+++ b/src/defaultAppConfig.js
@@ -1,3 +1,5 @@
+const httpPort = 8081 || process.env.PORT;
+
 const defaultAppConfig = {
   name: "Zoapp backend",
   version: "0.1.0",
@@ -16,12 +18,10 @@ const defaultAppConfig = {
       version: "1",
       port: 8081,
     },
-  },
-  backend: {
-    managementEndpoint: process.env.ZOAPP_MANAGEMENT_ENDPOINT === "true",
-    publicUrl: process.env.ZOAPP_PUBLIC_URL,
-    apiUrl: process.env.ZOAPP_API_URL,
-    authUrl: process.env.ZOAPP_AUTH_URL,
+    management_endpoint: false,
+    public_url: `http://localhost:${httpPort}/`,
+    api_url: `http://localhost:${httpPort}/api/v1/`,
+    auth_url: `http://localhost:${httpPort}/auth/`,
   },
   auth: {
     database: {
@@ -56,7 +56,7 @@ const defaultAppConfig = {
       name: "parameters",
     },
   },
-  buildSchema: true,
+  build_schema: true,
 };
 
 export default defaultAppConfig;

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,12 @@ import { merge } from "lodash";
 
 const fs = require("fs");
 
-// load config/default.json configuration if present.
+// load config.json configuration if present.
 let userConfig = {};
 try {
-  userConfig = JSON.parse(fs.readFileSync("config/default.json"));
+  userConfig = JSON.parse(fs.readFileSync("config.json"));
 } catch (error) {
-  logger.info("No config/default.json file provided");
+  logger.info("No config.json file provided, falling back to default config.");
 }
 
 // merge default and user configuration

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -94,9 +94,13 @@ export default zoapp => {
     admin.getParameterValue,
   );
 
-  if (config.backend.managementEndpoint === true) {
+  if (config.global.management_endpoint) {
+    logger.warn(`
+        Management endpoint enabled at '${config.global.management_endpoint}'
+    >>  MAKE SURE THIS IS NOT PUBLICLY ACCESSIBLE !`,
+    );
     //management routes
-    route = zoapp.createRoute("/management");
+    route = zoapp.createRoute(config.global.management_endpoint);
     route.add("GET", "/", ["open"], () => ({ status: "active" }));
     route.add("GET", "/users", ["open"], management.listUsers);
     route.add("POST", "/users", ["open"], management.createUser);

--- a/src/zoapp.js
+++ b/src/zoapp.js
@@ -11,9 +11,11 @@ import Controller from "./controllers/abstractController";
 import Model from "./models/abstractModel";
 import CommonRoutes from "./routes/common";
 import defaultAppConfig from "./defaultAppConfig";
+import _ from "lodash";
 
-const createZoapp = (config, log = "debug") => {
+const createZoapp = (configOverride, log = "debug") => {
   setupLogger(log);
+  const config = createConfig(configOverride, process.env);
   const server = createApiServer(config);
   const app = createApp(config, server);
 
@@ -32,6 +34,22 @@ const createZoapp = (config, log = "debug") => {
   return app;
 };
 
-export { Controller, Model, CommonRoutes, defaultAppConfig };
+const createConfig = (configOverride, env) => {
+  // Config priority is :
+  // 1. Environment vars starting with ZOAPP_
+  // 2. Config in configOverride
+  // 3. Fallback to ./defaultAppConfig
+  let finalConfig = defaultAppConfig;
+  finalConfig = _.merge({}, finalConfig, configOverride);
+  for (const envKey in _.pickBy(env, (v, k) => k.startsWith("ZOAPP__"))) {
+    if (env.hasOwnProperty(envKey)) {
+      const splittedKey = envKey.split("__").splice(1);
+      _.set(finalConfig, splittedKey.join(".").toLowerCase(), env[envKey]);
+    }
+  }
+  return finalConfig;
+};
+
+export { Controller, Model, CommonRoutes, defaultAppConfig, createConfig };
 
 export default createZoapp;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -13,7 +13,7 @@ jest.mock("../src/routes");
 
 describe("App", () => {
   const defaultTestConfiguration = JSON.parse(`
-    {"name":"Opla.ai","version":"0.1.0","global":{"database":{"datatype":"mysql","host":"127.0.0.1","name":"opla_dev","user":"root","password":"","charset":"utf8mb4","version":"2"},"api":{"endpoint":"/api","version":"42","port":8081},"botSite":{"url":"/publish/"},"gateway":{"url":"https://gateway.opla.ai"}},"auth":{"database":{"parent":"global","name":"auth"},"api":{"endpoint":"/auth"}},"messenger":{"database":{"parent":"global","name":"messenger"}},"users":{"database":{"parent":"global","name":"users"}},"bots":{"database":{"parent":"global","name":"bots"}},"webhooks":{"database":{"parent":"global","name":"webhooks"}},"middlewares":{"database":{"parent":"global","name":"middlewares"}},"parameters":{"database":{"parent":"global","name":"parameters"}},"buildSchema":false}
+    {"name":"Opla.ai","version":"0.1.0","global":{"database":{"datatype":"mysql","host":"127.0.0.1","name":"opla_dev","user":"root","password":"","charset":"utf8mb4","version":"2"},"api":{"endpoint":"/api","version":"42","port":8081},"botSite":{"url":"/publish/"},"gateway":{"url":"https://gateway.opla.ai"}},"auth":{"database":{"parent":"global","name":"auth"},"api":{"endpoint":"/auth"}},"messenger":{"database":{"parent":"global","name":"messenger"}},"users":{"database":{"parent":"global","name":"users"}},"bots":{"database":{"parent":"global","name":"bots"}},"webhooks":{"database":{"parent":"global","name":"webhooks"}},"middlewares":{"database":{"parent":"global","name":"middlewares"}},"parameters":{"database":{"parent":"global","name":"parameters"}},"build_schema":false}
   `);
   describe("constructor", () => {
     it("create App with user configuration", () => {
@@ -24,7 +24,7 @@ describe("App", () => {
       expect(configuration.name).toBeDefined();
       expect(configuration.global).toBeDefined();
       expect(configuration.global.database).toBeDefined();
-      expect(configuration.buildSchema).toBeDefined();
+      expect(configuration.build_schema).toBeDefined();
 
       expect(configuration.api).not.toBeDefined();
       expect(configuration.global.api).toBeDefined();
@@ -33,7 +33,7 @@ describe("App", () => {
       const app = new App(configuration, {});
 
       expect(app.buildSchema).toEqual(false);
-      expect(configuration.buildSchema).toBeDefined();
+      expect(configuration.build_schema).toBeDefined();
 
       // create database
       expect(createDBSpy).toHaveBeenCalledWith(configuration);
@@ -63,7 +63,7 @@ describe("App", () => {
       const app = new App(configuration, {});
 
       expect(app.buildSchema).toEqual(true);
-      expect(configuration.buildSchema).toBeDefined();
+      expect(configuration.build_schema).toBeDefined();
 
       // build database
       expect(createDBSpy).toHaveBeenCalledWith(defaultAppConfig);


### PR DESCRIPTION
- Allows to override env variables in a generic way :
`{"a": {"b": {"a_key": "a value"}}}` can be overridden by `ZOAPP__A__B__A_KEY="a value"`
`.` <=> `__`
- Moves `config/default.json` to config.json at the root of the project.
  Motivation is that `default.json` is absolutely not a default config file. It's, on the contrary, something that overrides `./src/defaultAppConfig.js`. Naming it `default.json` was misleading. `./config/config.json` would have been redundant useless complexity. ==> moving it to `./config.json`. It only matters for `zoapp-backend` anyways.
- In opla and other depending apps, the config object passed to `createZoapp()` function is now overriding `./defaultAppConfig.js` as it should.

### Config sources & priorities
1. Environment vars starting with `ZOAPP_`
2. Config in `createZoapp(config, ...)`
3. Fallback to `./src/defaultAppConfig.js`

### Backwards compatibility
**This is a BREAKING change. A PR to update opla will follow.**
I will make sure that, in Opla, `./config/default.json` is still taken into account for backwards compatibility reasons.