### PR TITLE
Add simple gravatar support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "validate.js": "^0.12.0",
     "ws": "^3.3.3",
     "zoapp-core": "0.13.0",
-    "zoauth-server": "0.10.4"
+    "zoauth-server": "0.10.5"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -112,9 +112,6 @@ export default class extends AbstractController {
   async storeProfile(profile) {
     const p = await this.model.storeProfile(profile);
     // callback(p);
-    if (p.id) {
-      p.id = null;
-    }
     return p;
   }
 }

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -112,6 +112,9 @@ export default class extends AbstractController {
   async storeProfile(profile) {
     const p = await this.model.storeProfile(profile);
     // callback(p);
+    if (p.id) {
+      p.id = null;
+    }
     return p;
   }
 }

--- a/src/utils/gravatar.js
+++ b/src/utils/gravatar.js
@@ -1,0 +1,26 @@
+import crypto from "crypto";
+import fetch from "node-fetch";
+
+const GravatarHandler = {
+  async fetchGravatar(email) {
+    try {
+      const response = await fetch(this.getGravatarUrl(email));
+      return { url: (await response.json()).entry[0].photos[0].value };
+    } catch (err) {
+      return { error: "Failed fetching gravatar", status: 500 };
+    }
+  },
+  getGravatarUrl(email, format = "json") {
+    if (!["json", "xml", "php", "vcf", "qr"].includes(format)) {
+      throw new Error("while fetching gravatar. Requested format not allowed");
+    }
+    const GRAVATAR_BASE_URL = "https://www.gravatar.com";
+    const md5email = `/${crypto
+      .createHash("md5")
+      .update(email)
+      .digest("hex")}`;
+    return `${GRAVATAR_BASE_URL + md5email}.json`;
+  },
+};
+
+export default GravatarHandler;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5860,10 +5860,10 @@ zoapp-core@0.13.0:
     nodemailer "4.6.8"
     winston "2.4.0"
 
-zoauth-server@0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/zoauth-server/-/zoauth-server-0.10.5.tgz#be928bd29aae435f15b86a7a1e7de80219170d8a"
-  integrity sha512-lkkxdp0D6eoq7JSgWeCMD+1n5TwtyhIeQma+GZjkRoAjGM9ok+96s3rv/+QdnPzICpYs5WMETcTlDrrkKOCK+w==
+zoauth-server@0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/zoauth-server/-/zoauth-server-0.10.4.tgz#f1d0c644afc102d3173520f9faa401e4af40f0ae"
+  integrity sha512-euHqFUhu2GDs32t93nJnAF0yKZjM11tywg2sQgjTtBPuntajTmZlcpNyiuC/cKUkhghyUqVsjkZTzw8+LkUdYw==
   dependencies:
     body-parser "^1.17.2"
     express "^4.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5860,10 +5860,10 @@ zoapp-core@0.13.0:
     nodemailer "4.6.8"
     winston "2.4.0"
 
-zoauth-server@0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/zoauth-server/-/zoauth-server-0.10.4.tgz#f1d0c644afc102d3173520f9faa401e4af40f0ae"
-  integrity sha512-euHqFUhu2GDs32t93nJnAF0yKZjM11tywg2sQgjTtBPuntajTmZlcpNyiuC/cKUkhghyUqVsjkZTzw8+LkUdYw==
+zoauth-server@0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/zoauth-server/-/zoauth-server-0.10.5.tgz#be928bd29aae435f15b86a7a1e7de80219170d8a"
+  integrity sha512-lkkxdp0D6eoq7JSgWeCMD+1n5TwtyhIeQma+GZjkRoAjGM9ok+96s3rv/+QdnPzICpYs5WMETcTlDrrkKOCK+w==
   dependencies:
     body-parser "^1.17.2"
     express "^4.15.3"


### PR DESCRIPTION
# Description

Add simple gravatar support. Gravatar will be saved in db when profile is created, or when user ask for a renew 


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Should add more tests cases for new gravatar features

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.1/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
