### PR TITLE
Fix settings issues, now using real user profile id instead of sent id

### DIFF
--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -94,6 +94,7 @@ class Users extends CommonRoutes {
       const updatedProfile = context.getBody();
       const result = await this.controller.getUsers().updateProfile({
         ...updatedProfile,
+        id: existingProfile.id,
         userId,
       });
       payload = Users.profile(result);


### PR DESCRIPTION
# Description

Fix an error where `userId` was passed in parameters instead of real `profile.id` when updating a user, causing profile to be duplicated

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

We may need to add a test in order to check if profile is not duplicated

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.1/v5.6.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code